### PR TITLE
Een lettertje vergeten... (faulty switch statement)

### DIFF
--- a/CRM/SolImport/CodImport.php
+++ b/CRM/SolImport/CodImport.php
@@ -10,6 +10,7 @@
 class CRM_SolImport_CodImport extends CRM_SolImport_AbstractImport {
 
   private $contactId;
+  private $config;
 
   function process() {
     $cod = $this->_sourceData->cod;
@@ -21,7 +22,7 @@ class CRM_SolImport_CodImport extends CRM_SolImport_AbstractImport {
       return FALSE;
     }
 
-    $config = CRM_SolImport_Config::singleton();
+    $this->config = CRM_SolImport_Config::singleton();
 
     $codes = str_split($cod, 3);
 
@@ -44,7 +45,7 @@ class CRM_SolImport_CodImport extends CRM_SolImport_AbstractImport {
   private function addGroup($code) {
 
     $result = civicrm_api3('GroupContact', 'create', [
-      'group_id' => $config->getGroupId($code),
+      'group_id' => $this->config->getGroupId($code),
       'contact_id' => $this->contactId,
     ]);
     if ($result['is_error']) {

--- a/CRM/SolImport/CodImport.php
+++ b/CRM/SolImport/CodImport.php
@@ -26,7 +26,7 @@ class CRM_SolImport_CodImport extends CRM_SolImport_AbstractImport {
     $codes = str_split($cod, 3);
 
     foreach ($codes as $code) {
-      switch ($codes) {
+      switch ($code) {
         case 'SYM':
         case 'SY1':
         case 'REL':


### PR DESCRIPTION
Script runs 3x as fast :)
$ time drush cvapi SolImport.cod limit=200000000
...
3074 rows import to CiviCRM, 101 with logged errors that were not imported
...
real 0m50.216s
vs
real 2m20.537s